### PR TITLE
New RabbitMQ version 3.6.0-management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rabbitmq:3.5.0-management
+FROM rabbitmq:3.6.0-management
 MAINTAINER Renato Silva <resilva87@outlook.com>
 
-RUN rabbitmq-plugins enable rabbitmq_stomp
+RUN rabbitmq-plugins enable rabbitmq_stomp --offline
 
 EXPOSE 61613


### PR DESCRIPTION
also plugin installation should be offline